### PR TITLE
Wrong order of operations in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM node:alpine AS builder
 WORKDIR /app
 COPY . .
 COPY --from=deps /app/node_modules ./node_modules
-RUN yarn build && yarn install --production --ignore-scripts --prefer-offline
+RUN yarn install --production --ignore-scripts --prefer-offline && yarn build
 
 # Production image, copy all the files and run next
 FROM node:alpine AS runner


### PR DESCRIPTION
I think the order of operations are wrong here, first we should run `yarn install` and then `yarn build`.