### PR TITLE
Handle Non-Google Huawei Devices

### DIFF
--- a/lib/download.ts
+++ b/lib/download.ts
@@ -6,9 +6,9 @@ export const getOS = () => {
   if (/windows phone/i.test(userAgent)) {
     return undefined
   }
-  
+
   // Non-Google Huawei detection from: https://stackoverflow.com/questions/66048820
-  if(/HMSCore\//.test(userAgent) && !/GMS\//.test(userAgent)) {
+  if (/HMSCore\//.test(userAgent) && !/GMS\//.test(userAgent)) {
     return "huawei"
   }
 

--- a/lib/download.ts
+++ b/lib/download.ts
@@ -6,6 +6,11 @@ export const getOS = () => {
   if (/windows phone/i.test(userAgent)) {
     return undefined
   }
+  
+  // Non-Google Huawei detection from: https://stackoverflow.com/questions/66048820
+  if(/HMSCore\//.test(userAgent) && !/GMS\//.test(userAgent)) {
+    return "huawei"
+  }
 
   if (/android/i.test(userAgent)) {
     return "android"


### PR DESCRIPTION
This PR will stop redirecting non-Google Huawei devices to the Google Play Store. Currently, Huawei devices that do not have Google Play Services will still be redirected to the Play Store when attempting to navigate to the `/download` URI. Instead, we want to keep them on the download page and allow them to download the .apk file directly.