### PR TITLE
ci: fix duplicate get version, make version trigger bump

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -126,11 +126,11 @@ jobs:
             trigger: true
             passed: [ release ]
           - get: version
+            trigger: true
             passed: [ release ]
           - get: charts-repo
             params: { skip_download: true }
           - get: pipeline-tasks
-          - get: version
       - task: bump-image-digest-in-values
         config:
           platform: linux


### PR DESCRIPTION
Oops, made `get: version` twice.
Also, made version trigger bump after release.