### PR TITLE
fix: fix zero leading input when changing between SAT and USD units

### DIFF
--- a/components/ParsePOSPayment/Digit-Button.tsx
+++ b/components/ParsePOSPayment/Digit-Button.tsx
@@ -4,12 +4,16 @@ import { ACTIONS, ACTION_TYPE } from "../../pages/_reducer"
 
 interface Props {
   digit: string
+  disabled?: boolean
   dispatch: React.Dispatch<ACTION_TYPE>
 }
 
-function DigitButton({ digit, dispatch }: Props) {
+function DigitButton({ digit, disabled, dispatch }: Props) {
   return (
-    <button onClick={() => dispatch({ type: ACTIONS.ADD_DIGIT, payload: digit })}>
+    <button
+      disabled={disabled}
+      onClick={() => dispatch({ type: ACTIONS.ADD_DIGIT, payload: digit })}
+    >
       {digit}
     </button>
   )

--- a/components/ParsePOSPayment/index.tsx
+++ b/components/ParsePOSPayment/index.tsx
@@ -214,7 +214,11 @@ function ParsePayment({ defaultWalletCurrency, walletId, dispatch, state }: Prop
           <DigitButton digit={"7"} dispatch={dispatch} />
           <DigitButton digit={"8"} dispatch={dispatch} />
           <DigitButton digit={"9"} dispatch={dispatch} />
-          <DigitButton digit={"."} dispatch={dispatch} />
+          <DigitButton
+            digit={"."}
+            dispatch={dispatch}
+            disabled={unit === AmountUnit.Sat}
+          />
           <DigitButton digit={"0"} dispatch={dispatch} />
           <button onClick={() => dispatch({ type: ACTIONS.DELETE_DIGIT })}>
             <Image

--- a/pages/_reducer.tsx
+++ b/pages/_reducer.tsx
@@ -41,6 +41,11 @@ function reducer(state: React.ComponentState, { type, payload }: ACTION_TYPE) {
     case ACTIONS.SET_AMOUNT_FROM_PARAMS:
       if (state.currentAmount == null) return state
       if (payload?.toString().match(/(\.[0-9]{2,}$|\..*\.)/)) {
+        if (payload?.toString() === "0.00")
+          return {
+            ...state,
+            currentAmount: "0",
+          }
         return {
           ...state,
           currentAmount: Number(payload).toFixed(2),


### PR DESCRIPTION
This PR fixes the issue of having fixed zero inputs when switching between SAT and USD units when the current amount is 0 or null.
I've also fixed the issue where users might accidentally add a dot/period (.) when the unit is in SAT which throws an error.
The dot/period button will be disabled when the unit is in SAT for better UX.