### PR TITLE
feat: remove toggle currency button when invoice is created

### DIFF
--- a/components/ParsePOSPayment/index.tsx
+++ b/components/ParsePOSPayment/index.tsx
@@ -184,14 +184,16 @@ function ParsePayment({ defaultWalletCurrency, walletId, dispatch, state }: Prop
         >
           {unit === AmountUnit.Cent ? valueInSats : valueInSats.slice(1, -1)}
         </div>
-        <button title="toggle currency" onClick={() => toggleCurrency()}>
-          <Image
-            src="/icons/convert-icon.svg"
-            alt="convert to SAT/USD icon"
-            width="24"
-            height="24"
-          />
-        </button>
+        {state.createdInvoice ? null : (
+          <button title="toggle currency" onClick={() => toggleCurrency()}>
+            <Image
+              src="/icons/convert-icon.svg"
+              alt="convert to SAT/USD icon"
+              width="24"
+              height="24"
+            />
+          </button>
+        )}
       </div>
 
       <Memo createdInvoice={state.createdInvoice} />


### PR DESCRIPTION
The pr introduces a fix for #424  to remove/disable the toggle currency button after an invoice is created